### PR TITLE
feat: Update Mini plan statement limit to 90

### DIFF
--- a/src/components/features/PlanComparisonTable.tsx
+++ b/src/components/features/PlanComparisonTable.tsx
@@ -35,7 +35,7 @@ interface PlanPricing {
 const planFeatures: PlanFeature[] = [
     {
         name: 'Upload statements per month',
-        tiers: { basic: '80', premium: '200', ultimate: 'Unlimited' }
+        tiers: { basic: '90', premium: '200', ultimate: 'Unlimited' }
     },
     {
         name: 'AI Transaction Categorization',


### PR DESCRIPTION
This commit updates the pricing plan for the "Mini" plan in the plan comparison table. The statement limit per month has been increased from 80 to 90.